### PR TITLE
Fix #41 :  Add Split Lines Before/After

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
         "onCommand:dakara-transformer.sortByLineLength",
         "onCommand:dakara-transformer.sortLines",
         "onCommand:dakara-transformer.splitLines",
+        "onCommand:dakara-transformer.splitLinesBeforeDelimiter",
+        "onCommand:dakara-transformer.splitLinesAfterDelimiter",
         "onCommand:dakara-transformer.trimLines",
         "onCommand:dakara-transformer.uniqueLines",
         "onCommand:dakara-transformer.uniqueLinesNewDocument"
@@ -192,6 +194,16 @@
             {
                 "command": "dakara-transformer.splitLines",
                 "title": "Split Lines...",
+                "category": "Transform"
+            },
+            {
+                "command": "dakara-transformer.splitLinesBeforeDelimiter",
+                "title": "Split Lines Before...",
+                "category": "Transform"
+            },
+            {
+                "command": "dakara-transformer.splitLinesAfterDelimiter",
+                "title": "Split Lines After...",
                 "category": "Transform"
             }
         ],

--- a/src/Transforms.ts
+++ b/src/Transforms.ts
@@ -397,6 +397,18 @@ export async function splitLines(textEditor: vscode.TextEditor) {
     Modify.replaceUsingTransform(textEditor, textEditor.selections, text => text.split(userInput).join(splitChar))
 }
 
+export async function splitLinesBeforeDelimiter(textEditor: vscode.TextEditor) {
+    const userInput = await vscode.window.showInputBox({prompt:'Specify Delimiter', value: ''});
+    const splitChar = Lines.lineEndChars(textEditor) + userInput
+    Modify.replaceUsingTransform(textEditor, textEditor.selections, text => text.split(userInput).join(splitChar))
+}
+
+export async function splitLinesAfterDelimiter(textEditor: vscode.TextEditor) {
+    const userInput = await vscode.window.showInputBox({prompt:'Specify Delimiter', value: ''});
+    const splitChar =  userInput + Lines.lineEndChars(textEditor)
+    Modify.replaceUsingTransform(textEditor, textEditor.selections, text => text.split(userInput).join(splitChar))
+}
+
 export function escapes(textEditor: vscode.TextEditor) {
     const selections = textEditor.selections
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,6 +208,16 @@ export function activate(context: vscode.ExtensionContext) {
         transforms.splitLines(textEditor);
     });
 
+    Application.registerCommand(context, 'dakara-transformer.splitLinesBeforeDelimiter', () => {
+        const textEditor = vscode.window.activeTextEditor;
+        transforms.splitLinesBeforeDelimiter(textEditor);
+    });
+
+    Application.registerCommand(context, 'dakara-transformer.splitLinesAfterDelimiter', () => {
+        const textEditor = vscode.window.activeTextEditor;
+        transforms.splitLinesAfterDelimiter(textEditor);
+    });
+
 
 }
 


### PR DESCRIPTION
splitLinesBeforeDelimiter
splitLinesAfterDelimiter

I also could have altetred splitLines to support an additional param to choose what the `splitChar` should be.